### PR TITLE
Fix ccache not populating: set CCACHE_DIR explicitly

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -48,6 +48,7 @@ jobs:
         network: ["TEST", "BETA", "LIVE"]
     env:
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -95,6 +96,7 @@ jobs:
         network: ["TEST", "BETA", "LIVE"]
     env:
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -33,6 +33,7 @@ jobs:
       TSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../tsan_suppressions
       UBSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:print_stacktrace=1
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -98,6 +99,7 @@ jobs:
       TSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:suppressions=../tsan_suppressions
       UBSAN_OPTIONS: log_exe_name=1:log_path=sanitizer_report:print_stacktrace=1
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -17,6 +17,7 @@ jobs:
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     runs-on: macos-14
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
@@ -77,6 +78,7 @@ jobs:
       TEST_USE_ROCKSDB: ${{ matrix.BACKEND == 'rocksdb' && '1' || '0' }}
       DEADLINE_SCALE_FACTOR: ${{ matrix.BACKEND == 'rocksdb' && '2' || '1' }}
       CCACHE_MAXSIZE: 200M
+      CCACHE_DIR: ~/.ccache
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout


### PR DESCRIPTION
ccache 4.x (shipped with Ubuntu 24.04 and current Homebrew) defaults to ~/.cache/ccache instead of ~/.ccache. On a fresh GitHub runner ~/.ccache never exists, so ccache writes there while actions/cache saves/restores the empty ~/.ccache path — resulting in an always-empty cache.

Adding CCACHE_DIR=~/.ccache to each job's env forces ccache to use the path that is actually being cached.

https://claude.ai/code/session_01FsF18hYT2ZTDWK8NVN3HPm