### PR TITLE
Drop BACKEND from sccache cache key

### DIFF
--- a/.github/workflows/code_sanitizers.yml
+++ b/.github/workflows/code_sanitizers.yml
@@ -35,7 +35,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}-${{ matrix.BACKEND }}
+      SCCACHE_GHA_VERSION: linux-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout
@@ -102,7 +102,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: macos-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.BACKEND }}-${{ matrix.COMPILER }}
+      SCCACHE_GHA_VERSION: macos-sanitizers-${{ matrix.SANITIZER.name }}-${{ matrix.COMPILER }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,7 +19,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: macos-${{ matrix.BACKEND }}-${{ matrix.RELEASE }}
+      SCCACHE_GHA_VERSION: macos-${{ matrix.RELEASE }}
     runs-on: macos-14
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
@@ -81,7 +81,7 @@ jobs:
       CMAKE_C_COMPILER_LAUNCHER: sccache
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: "true"
-      SCCACHE_GHA_VERSION: linux-${{ matrix.COMPILER }}-${{ matrix.BACKEND }}-${{ matrix.RELEASE }}
+      SCCACHE_GHA_VERSION: linux-${{ matrix.COMPILER }}-${{ matrix.RELEASE }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
       - name: Checkout


### PR DESCRIPTION
BACKEND (lmdb/rocksdb) only affects runtime test config and is not passed to cmake in ci/build.sh, so the compiled objects are identical across backends. Including BACKEND in SCCACHE_GHA_VERSION was fragmenting the cache for no correctness benefit.

https://claude.ai/code/session_01GVw4XksxL9NN3MvKdGtA5h